### PR TITLE
Updating python runtime to 3.9.7

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.5
+python-3.9.7


### PR DESCRIPTION
Updating to latest version of python 3.9.
Recommended by Heroku.
![image](https://user-images.githubusercontent.com/86045695/140291646-0c122629-c7a5-40f1-a589-c5d81228c7d2.png)
